### PR TITLE
📈 Add basic analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eject": "react-scripts eject",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
-  "proxy": "http://localhost:4001/",
+  "proxy": "http://localhost:4000/",
   "eslintConfig": {
     "extends": "react-app"
   },

--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,15 @@
       name="What's Up Kent"
       content="Find out everything going on at the University of Kent, without nagging all of your mates."
     />
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-133320080-4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'UA-133320080-4');
+    </script>
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/


### PR DESCRIPTION
Should probably change this to use react-ga in the future to track outbound links, and specific page views. But for now this will do.
Closes #11 although should probably create a new issue for the advanced analytics